### PR TITLE
Extend OpenAI configuration support

### DIFF
--- a/examples/00_quickstart.ipynb
+++ b/examples/00_quickstart.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# PromptCraft Quickstart\n",
+    "Use this notebook to explore the PromptCraft workflow in an interactive environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import promptcraft\n",
+    "\n",
+    "print(f\"PromptCraft version: {promptcraft.__version__}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/01_bulk_rewrite.ipynb
+++ b/examples/01_bulk_rewrite.ipynb
@@ -1,0 +1,38 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bulk Rewrite Demo\n",
+    "Sketch how to organise batches of prompts before sending them to the API."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from promptcraft.models import Prompt\n",
+    "\n",
+    "batch = [Prompt(text=entry) for entry in (\"Draft email\", \"Summarise call\")]\n",
+    "[prompt.text for prompt in batch]"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/02_scoring_demo.ipynb
+++ b/examples/02_scoring_demo.ipynb
@@ -1,0 +1,37 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Prompt Scoring Demo\n",
+    "This notebook illustrates how to score prompts with PromptCraft metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from promptcraft.metrics import score_prompt\n",
+    "\n",
+    "score_prompt(\"Describe the solar system in two sentences.\").overall"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/03_llm_finetune.ipynb
+++ b/examples/03_llm_finetune.ipynb
@@ -1,0 +1,114 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# LLM Finetuning Walkthrough\n",
+        "Use this notebook as a lightweight checklist for preparing a custom fine-tuned model with PromptCraft tooling.\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Prerequisites\n",
+        "- Install the optional OpenAI SDK: `pip install openai`\n",
+        "- Configure credentials via `PROMPTCRAFT_OPENAI_API_KEY` (and optional base URL or organization overrides)\n",
+        "- Gather high-quality prompt/completion pairs that reflect the behaviour you expect from the tuned model\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from promptcraft.models import Prompt\n",
+        "\n",
+        "training_plan = [\n",
+        "    {\n",
+        "        \"input\": Prompt(text=\"Summarize release notes for executives.\"),\n",
+        "        \"ideal\": \"Provide a three-bullet executive summary.\",\n",
+        "    },\n",
+        "    {\n",
+        "        \"input\": Prompt(text=\"Draft a customer apology email using issue details.\"),\n",
+        "        \"ideal\": \"Write a concise, empathetic apology and remediation plan.\",\n",
+        "    },\n",
+        "]\n",
+        "training_plan\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Upload curated data\n",
+        "Use your storage backend or the OpenAI files API to upload JSONL documents that mirror the `training_plan` skeleton.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from promptcraft.ai_client import AIClient\n",
+        "\n",
+        "client = AIClient(model=\"gpt-4o-mini\")\n",
+        "job_request = {\n",
+        "    \"training_file\": \"file-abc123\",\n",
+        "    \"validation_file\": \"file-def456\",\n",
+        "    \"model\": client.model,\n",
+        "}\n",
+        "job_request\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Track experiments\n",
+        "Capture dataset references and prompt variants alongside PromptCraft sessions so that results remain reproducible.\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from promptcraft.models import Session\n",
+        "\n",
+        "session = Session(\n",
+        "    user_id=\"finetune-pipeline\",\n",
+        "    prompts=[entry[\"input\"].text for entry in training_plan],\n",
+        ")\n",
+        "session\n"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Next steps\n",
+        "1. Submit the request with `openai.fine_tuning.jobs.create(**job_request)` once files are uploaded.\n",
+        "2. Monitor job status using `openai.fine_tuning.jobs.retrieve(job_id)` and log checkpoints in PromptCraft.\n",
+        "3. Evaluate the tuned model with the scoring helpers in `examples/02_scoring_demo.ipynb`.\n"
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "Python 3",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python",
+      "version": "3.12.10"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/promptcraft/__init__.py
+++ b/promptcraft/__init__.py
@@ -1,4 +1,6 @@
 """PromptCraft package."""
 
-from ._version import __version__
-from .prompt import rewrite
+from ._version import __version__ as __version__
+from .prompt import rewrite as rewrite
+
+__all__ = ["__version__", "rewrite"]

--- a/promptcraft/ai_client.py
+++ b/promptcraft/ai_client.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from types import SimpleNamespace
 from typing import Any, Protocol
 
@@ -20,29 +21,110 @@ class _OpenAIProtocol(Protocol):
     ChatCompletion: _ChatCompletion
 
 
-def _load_openai() -> _OpenAIProtocol:
-    """Return the OpenAI ChatCompletion client or a helpful stub.
+class _OpenAIShim:
+    """Compatibility wrapper for the OpenAI 1.x client.
 
-    Importing ``openai`` at module load time makes tests fail when the optional
-    dependency is not installed.  Instead we lazily import the module and fall
-    back to a stub that raises a descriptive error when actually invoked.  Test
-    suites can still monkeypatch ``promptcraft.ai_client.openai`` thanks to the
-    attribute assignment below.
+    The 1.x release removed the ``ChatCompletion`` module-level helper and
+    requires instantiating :class:`openai.OpenAI`.  This shim exposes an object
+    compatible with the legacy interface used throughout the code base while
+    lazily constructing the modern client when needed.
     """
 
-    try:  # pragma: no cover - exercised indirectly via tests
-        import openai as _openai
-    except ModuleNotFoundError as exc:  # pragma: no cover - behaviour asserted in tests
-        class _MissingOpenAI:
-            class ChatCompletion:
-                @staticmethod
-                def create(*args: Any, **kwargs: Any) -> Any:
-                    raise RuntimeError(
-                        "The 'openai' package is required for API interactions. "
-                        "Install it with `pip install openai` or configure a mock."
-                    ) from exc
+    _FORWARDED_ATTRS = {
+        "api_key",
+        "base_url",
+        "organization",
+        "timeout",
+        "max_retries",
+        "default_headers",
+    }
 
-        return SimpleNamespace(ChatCompletion=_MissingOpenAI.ChatCompletion)
+    def __init__(self, openai_module: Any):
+        object.__setattr__(self, "_openai_module", openai_module)
+        object.__setattr__(self, "_client", None)
+        object.__setattr__(self, "_client_kwargs", {})
+        object.__setattr__(
+            self,
+            "ChatCompletion",
+            SimpleNamespace(create=self._create_chat_completion),
+        )
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str,
+        messages: list[dict[str, str]],
+        **kwargs: Any,
+    ) -> Any:
+        client = object.__getattribute__(self, "_client")
+        if client is None:
+            client_kwargs: dict[str, Any] = dict(
+                object.__getattribute__(self, "_client_kwargs")
+            )
+            openai_module = object.__getattribute__(self, "_openai_module")
+            client = openai_module.OpenAI(**client_kwargs)
+            object.__setattr__(self, "_client", client)
+        return client.chat.completions.create(model=model, messages=messages, **kwargs)
+
+    def __getattr__(self, name: str) -> Any:
+        if name in self._FORWARDED_ATTRS:
+            client_kwargs = object.__getattribute__(self, "_client_kwargs")
+            return client_kwargs.get(name)
+        openai_module = object.__getattribute__(self, "_openai_module")
+        return getattr(openai_module, name)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in self._FORWARDED_ATTRS:
+            client_kwargs = object.__getattribute__(self, "_client_kwargs")
+            if value is None or (name in {"api_key", "base_url", "organization"} and value == ""):
+                client_kwargs.pop(name, None)
+            else:
+                client_kwargs[name] = value
+            object.__setattr__(self, "_client", None)
+        else:
+            openai_module = object.__getattribute__(self, "_openai_module")
+            setattr(openai_module, name, value)
+
+
+def _default_import_openai() -> Any:
+    import openai as _openai  # type: ignore[import-not-found]
+
+    return _openai
+
+
+def _load_openai(importer: Callable[[], Any] | None = None) -> _OpenAIProtocol:
+    """Return the OpenAI ChatCompletion client or a helpful stub."""
+
+    importer = importer or _default_import_openai
+
+    try:  # pragma: no cover - exercised indirectly via tests
+        _openai = importer()
+    except ModuleNotFoundError as exc:  # pragma: no cover - behaviour asserted in tests
+        missing_exc = exc
+
+        class _MissingChatCompletion:
+            @staticmethod
+            def create(*args: Any, **kwargs: Any) -> Any:
+                raise RuntimeError(
+                    "The 'openai' package is required for API interactions. "
+                    "Install it with `pip install openai` or configure a mock."
+                ) from missing_exc
+
+        return SimpleNamespace(
+            ChatCompletion=_MissingChatCompletion,
+            api_key=None,
+            base_url=None,
+            organization=None,
+            timeout=None,
+            max_retries=None,
+            default_headers=None,
+        )
+
+    if hasattr(_openai, "ChatCompletion"):
+        return _openai  # legacy <1.0 API
+
+    if hasattr(_openai, "OpenAI"):
+        return _OpenAIShim(_openai)
 
     return _openai
 
@@ -55,9 +137,15 @@ class AIClient:
     def __init__(self, model: str = "gpt-4o"):
         self.model = model
         self.settings = get_settings()
-        # Configure API key if the real client is available
-        if hasattr(openai, "api_key") and self.settings.openai_api_key:
+        if self.settings.openai_api_key and hasattr(openai, "api_key"):
             setattr(openai, "api_key", self.settings.openai_api_key)
+        if self.settings.openai_base_url:
+            if hasattr(openai, "base_url"):
+                setattr(openai, "base_url", self.settings.openai_base_url)
+            elif hasattr(openai, "api_base"):
+                setattr(openai, "api_base", self.settings.openai_base_url)
+        if self.settings.openai_organization and hasattr(openai, "organization"):
+            setattr(openai, "organization", self.settings.openai_organization)
 
     def chat(self, prompt: str) -> str:
         cache_key = f"{self.model}:{prompt}"

--- a/promptcraft/config.py
+++ b/promptcraft/config.py
@@ -5,15 +5,88 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 
+try:  # pragma: no cover - prefer Pydantic implementation when available
+    from pydantic import Field
+    try:
+        from pydantic_settings import BaseSettings, SettingsConfigDict
+    except ImportError:  # pragma: no cover - fallback to Pydantic's BaseSettings
+        from pydantic import BaseSettings  # type: ignore
 
-@dataclass(slots=True)
-class Settings:
-    """Configuration values sourced from the environment."""
+        SettingsConfigDict = None  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fall back to dataclass implementation
+    Field = None  # type: ignore
+    BaseSettings = None  # type: ignore
+    SettingsConfigDict = None  # type: ignore
 
-    openai_api_key: str = ""
+
+if BaseSettings is None:  # pragma: no cover - executed when Pydantic is unavailable
+    @dataclass(slots=True)
+    class Settings:
+        """Configuration values sourced from the environment."""
+
+        openai_api_key: str = ""
+        openai_base_url: str = ""
+        openai_organization: str = ""
 
 
-def get_settings() -> Settings:
-    """Return application settings using environment fallbacks."""
+    def _env(*names: str, default: str = "") -> str:
+        for name in names:
+            value = os.getenv(name)
+            if value:
+                return value
+        return default
 
-    return Settings(openai_api_key=os.getenv("PROMPTCRAFT_OPENAI_API_KEY", ""))
+
+    def get_settings() -> Settings:
+        """Return application settings using environment fallbacks."""
+
+        return Settings(
+            openai_api_key=_env("PROMPTCRAFT_OPENAI_API_KEY", "OPENAI_API_KEY"),
+            openai_base_url=_env("PROMPTCRAFT_OPENAI_BASE_URL", "OPENAI_BASE_URL", "OPENAI_API_BASE"),
+            openai_organization=_env(
+                "PROMPTCRAFT_OPENAI_ORG",
+                "PROMPTCRAFT_OPENAI_ORGANIZATION",
+                "OPENAI_ORG",
+                "OPENAI_ORGANIZATION",
+            ),
+        )
+else:
+
+    class Settings(BaseSettings):
+        """Configuration values sourced from the environment."""
+
+        openai_api_key: str = Field(
+            default="",
+            env=["PROMPTCRAFT_OPENAI_API_KEY", "OPENAI_API_KEY"],
+        )
+        openai_base_url: str = Field(
+            default="",
+            env=[
+                "PROMPTCRAFT_OPENAI_BASE_URL",
+                "OPENAI_BASE_URL",
+                "OPENAI_API_BASE",
+            ],
+        )
+        openai_organization: str = Field(
+            default="",
+            env=[
+                "PROMPTCRAFT_OPENAI_ORG",
+                "PROMPTCRAFT_OPENAI_ORGANIZATION",
+                "OPENAI_ORG",
+                "OPENAI_ORGANIZATION",
+            ],
+        )
+
+        if SettingsConfigDict is not None:
+            model_config = SettingsConfigDict(env_prefix="", extra="ignore")
+        else:  # pragma: no cover - Pydantic v1 fallback
+            class Config:
+                env_prefix = ""
+                extra = "ignore"
+
+
+    def get_settings() -> Settings:
+        """Return application settings using environment fallbacks."""
+
+        return Settings()
+

--- a/promptcraft/models/prompt.py
+++ b/promptcraft/models/prompt.py
@@ -1,8 +1,33 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+try:  # pragma: no cover - prefer Pydantic models when available
+    from pydantic import BaseModel
+    try:
+        from pydantic import ConfigDict
+    except ImportError:  # pragma: no cover
+        ConfigDict = None  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fall back to dataclasses
+    BaseModel = None  # type: ignore
+    ConfigDict = None  # type: ignore
 
 
-@dataclass(slots=True)
-class Prompt:
-    """Simple representation of a prompt."""
+if BaseModel is None:  # pragma: no cover - executed when Pydantic is unavailable
+    from dataclasses import dataclass
 
-    text: str
+    @dataclass(slots=True)
+    class Prompt:
+        """Simple representation of a prompt."""
+
+        text: str
+else:
+
+    class Prompt(BaseModel):
+        """Simple representation of a prompt."""
+
+        text: str
+
+        if ConfigDict is not None:
+            model_config = ConfigDict(frozen=True)
+        else:  # pragma: no cover - Pydantic v1 fallback
+            class Config:
+                allow_mutation = False

--- a/promptcraft/models/score.py
+++ b/promptcraft/models/score.py
@@ -1,12 +1,41 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+try:  # pragma: no cover - prefer Pydantic models when available
+    from pydantic import BaseModel
+    try:
+        from pydantic import ConfigDict
+    except ImportError:  # pragma: no cover
+        ConfigDict = None  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fall back to dataclasses
+    BaseModel = None  # type: ignore
+    ConfigDict = None  # type: ignore
 
 
-@dataclass(slots=True)
-class Score:
-    """Score for a prompt based on several criteria."""
+if BaseModel is None:  # pragma: no cover - executed when Pydantic is unavailable
+    from dataclasses import dataclass
 
-    clarity: int
-    context: int
-    constraints: int
-    intent: int
-    overall: float
+    @dataclass(slots=True)
+    class Score:
+        """Score for a prompt based on several criteria."""
+
+        clarity: int
+        context: int
+        constraints: int
+        intent: int
+        overall: float
+else:
+
+    class Score(BaseModel):
+        """Score for a prompt based on several criteria."""
+
+        clarity: int
+        context: int
+        constraints: int
+        intent: int
+        overall: float
+
+        if ConfigDict is not None:
+            model_config = ConfigDict(frozen=True)
+        else:  # pragma: no cover - Pydantic v1 fallback
+            class Config:
+                allow_mutation = False

--- a/promptcraft/models/session.py
+++ b/promptcraft/models/session.py
@@ -1,9 +1,36 @@
-from dataclasses import dataclass, field
+from __future__ import annotations
+
+try:  # pragma: no cover - prefer Pydantic models when available
+    from pydantic import BaseModel, Field
+    try:
+        from pydantic import ConfigDict
+    except ImportError:  # pragma: no cover
+        ConfigDict = None  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fall back to dataclasses
+    BaseModel = None  # type: ignore
+    ConfigDict = None  # type: ignore
+    Field = None  # type: ignore
 
 
-@dataclass(slots=True)
-class Session:
-    """Record of a prompt crafting session."""
+if BaseModel is None:  # pragma: no cover - executed when Pydantic is unavailable
+    from dataclasses import dataclass, field
 
-    user_id: str
-    prompts: list[str] = field(default_factory=list)
+    @dataclass(slots=True)
+    class Session:
+        """Record of a prompt crafting session."""
+
+        user_id: str
+        prompts: list[str] = field(default_factory=list)
+else:
+
+    class Session(BaseModel):
+        """Record of a prompt crafting session."""
+
+        user_id: str
+        prompts: list[str] = Field(default_factory=list)
+
+        if ConfigDict is not None:
+            model_config = ConfigDict(validate_assignment=True)
+        else:  # pragma: no cover - Pydantic v1 fallback
+            class Config:
+                validate_assignment = True

--- a/promptcraft/models/user.py
+++ b/promptcraft/models/user.py
@@ -1,9 +1,35 @@
-from dataclasses import dataclass
+from __future__ import annotations
+
+try:  # pragma: no cover - prefer Pydantic models when available
+    from pydantic import BaseModel
+    try:
+        from pydantic import ConfigDict
+    except ImportError:  # pragma: no cover
+        ConfigDict = None  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fall back to dataclasses
+    BaseModel = None  # type: ignore
+    ConfigDict = None  # type: ignore
 
 
-@dataclass(slots=True)
-class User:
-    """User metadata."""
+if BaseModel is None:  # pragma: no cover - executed when Pydantic is unavailable
+    from dataclasses import dataclass
 
-    id: str
-    name: str
+    @dataclass(slots=True)
+    class User:
+        """User metadata."""
+
+        id: str
+        name: str
+else:
+
+    class User(BaseModel):
+        """User metadata."""
+
+        id: str
+        name: str
+
+        if ConfigDict is not None:
+            model_config = ConfigDict(frozen=True)
+        else:  # pragma: no cover - Pydantic v1 fallback
+            class Config:
+                allow_mutation = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ Homepage = "https://github.com/Dantheman23-coder/PromptCraft"
 Documentation = "https://promptcraft.readthedocs.io"
 
 [project.dependencies]
+click = "*"
 openai = "*"
 tinydb = "*"
 pydantic-settings = "*"

--- a/tests/test_ai_client.py
+++ b/tests/test_ai_client.py
@@ -1,7 +1,164 @@
-from promptcraft.ai_client import AIClient
+from types import SimpleNamespace
+
+import pytest
+
+from promptcraft.ai_client import (
+    AIClient,
+    _OpenAIShim,
+    _load_openai,
+)
+from promptcraft.config import get_settings
 
 
 def test_ai_client(monkeypatch):
     client = AIClient()
     monkeypatch.setattr("promptcraft.ai_client.openai.ChatCompletion.create", lambda **kwargs: type('x',(object,),{'choices':[type('x',(object,),{'message':type('x',(object,),{"content":"ok"})()})()]})())
     assert client.chat("hi") == "ok"
+
+
+class _StubOpenAIModule:
+    def __init__(self):
+        self.created_with: list[dict[str, object]] = []
+        self.requests: list[dict[str, object]] = []
+
+    class _Client:
+        def __init__(self, module: "_StubOpenAIModule", **kwargs):
+            module.created_with.append(kwargs)
+            self._module = module
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=module._record_request)
+            )
+
+    def OpenAI(self, **kwargs):  # noqa: N802 - replicates OpenAI module API
+        return self._Client(self, **kwargs)
+
+    def _record_request(self, **kwargs):
+        self.requests.append(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="stub-response"),
+                )
+            ]
+        )
+
+
+def test_openai_shim_forwards_settings_and_reinitialises():
+    stub_module = _StubOpenAIModule()
+    shim = _OpenAIShim(stub_module)
+
+    shim.api_key = "abc"
+    shim.base_url = "https://example.test"
+    shim.organization = "org-id"
+    shim.ChatCompletion.create(model="gpt", messages=[{"role": "user", "content": "hi"}])
+    assert stub_module.created_with == [
+        {
+            "api_key": "abc",
+            "base_url": "https://example.test",
+            "organization": "org-id",
+        }
+    ]
+    assert stub_module.requests == [
+        {"model": "gpt", "messages": [{"role": "user", "content": "hi"}]}
+    ]
+
+    shim.api_key = None
+    shim.base_url = ""
+    shim.organization = None
+    shim.ChatCompletion.create(model="gpt", messages=[{"role": "user", "content": "hi"}])
+    assert stub_module.created_with[-1] == {}
+    assert len(stub_module.created_with) == 2
+
+
+def test_load_openai_missing_dependency():
+    def _raise() -> None:
+        raise ModuleNotFoundError("openai not installed")
+
+    loaded = _load_openai(_raise)
+    with pytest.raises(RuntimeError):
+        loaded.ChatCompletion.create()
+
+
+def test_load_openai_prefers_legacy_chat_completion():
+    stub_module = SimpleNamespace(ChatCompletion=object(), api_key=None)
+
+    loaded = _load_openai(lambda: stub_module)
+    assert loaded is stub_module
+
+
+def test_ai_client_applies_environment_configuration(monkeypatch):
+    monkeypatch.setenv("PROMPTCRAFT_OPENAI_API_KEY", "promptcraft-key")
+    monkeypatch.setenv("PROMPTCRAFT_OPENAI_BASE_URL", "https://promptcraft.local")
+    monkeypatch.setenv("PROMPTCRAFT_OPENAI_ORG", "promptcraft-org")
+
+    stub_client = SimpleNamespace(
+        ChatCompletion=SimpleNamespace(
+            create=lambda **kwargs: SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            )
+        ),
+        api_key=None,
+        base_url=None,
+        organization=None,
+        api_base=None,
+    )
+
+    monkeypatch.setattr("promptcraft.ai_client.openai", stub_client)
+
+    client = AIClient()
+
+    assert stub_client.api_key == "promptcraft-key"
+    assert stub_client.base_url == "https://promptcraft.local"
+    assert stub_client.organization == "promptcraft-org"
+    assert client.chat("hi") == "ok"
+
+
+def test_ai_client_sets_legacy_api_base(monkeypatch):
+    monkeypatch.setenv("PROMPTCRAFT_OPENAI_BASE_URL", "https://promptcraft.local")
+
+    stub_client = SimpleNamespace(
+        ChatCompletion=SimpleNamespace(
+            create=lambda **kwargs: SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))]
+            )
+        ),
+        api_key=None,
+        api_base=None,
+    )
+
+    monkeypatch.setattr("promptcraft.ai_client.openai", stub_client)
+
+    AIClient()
+
+    assert stub_client.api_base == "https://promptcraft.local"
+
+
+def test_get_settings_prefers_promptcraft_environment(monkeypatch):
+    monkeypatch.setenv("PROMPTCRAFT_OPENAI_API_KEY", "promptcraft-key")
+    monkeypatch.setenv("OPENAI_API_KEY", "global-key")
+    monkeypatch.setenv("PROMPTCRAFT_OPENAI_BASE_URL", "https://promptcraft.local")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai.local")
+    monkeypatch.setenv("PROMPTCRAFT_OPENAI_ORGANIZATION", "promptcraft-org")
+    monkeypatch.setenv("OPENAI_ORGANIZATION", "global-org")
+
+    settings = get_settings()
+
+    assert settings.openai_api_key == "promptcraft-key"
+    assert settings.openai_base_url == "https://promptcraft.local"
+    assert settings.openai_organization == "promptcraft-org"
+
+
+def test_get_settings_falls_back_to_openai_environment(monkeypatch):
+    monkeypatch.delenv("PROMPTCRAFT_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("PROMPTCRAFT_OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("PROMPTCRAFT_OPENAI_ORG", raising=False)
+    monkeypatch.delenv("PROMPTCRAFT_OPENAI_ORGANIZATION", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "global-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://openai.local")
+    monkeypatch.setenv("OPENAI_ORG", "global-org")
+
+    settings = get_settings()
+
+    assert settings.openai_api_key == "global-key"
+    assert settings.openai_base_url == "https://openai.local"
+    assert settings.openai_organization == "global-org"


### PR DESCRIPTION
## Summary
- broaden the OpenAI shim to forward organization and other client arguments while delegating additional attributes to the underlying SDK
- teach the settings loader and AI client to propagate organization and legacy base URL variants, and refresh the fine-tuning notebook with actionable setup steps
- extend AI client tests to cover the richer configuration paths and environment fallbacks

## Testing
- pytest
- ruff check

------
https://chatgpt.com/codex/tasks/task_e_68d9fe2a1fc8832084c1c5c667b018d8